### PR TITLE
Split tests; use Python's unittest discovery

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+/usr/bin/env python -m unittest discover

--- a/test_dumpers.py
+++ b/test_dumpers.py
@@ -1,0 +1,46 @@
+import os
+import shutil
+import unittest
+import tempfile
+
+import igc_lib
+import dumpers
+
+
+class TestDumpers(unittest.TestCase):
+
+    def setUp(self):
+        igc_file = 'testfiles/napret.igc'
+        self.flight = igc_lib.Flight.create_from_file(igc_file)
+        self.tmp_output_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        # Best-effort removal of temporary output files
+        shutil.rmtree(self.tmp_output_dir, ignore_errors=True)
+
+    def assertFileNotEmpty(self, filename):
+        self.assertTrue(os.path.isfile(filename))
+        self.assertGreater(os.path.getsize(filename), 0)
+
+    def testWptDumpNotEmpty(self):
+        tmp_wpt_file = os.path.join(self.tmp_output_dir, 'thermals.wpt')
+        dumpers.dump_thermals_to_wpt_file(self.flight, tmp_wpt_file)
+        self.assertFileNotEmpty(tmp_wpt_file)
+
+    def testCupDumpNotEmpty(self):
+        tmp_cup_file = os.path.join(self.tmp_output_dir, 'thermals.cup')
+        dumpers.dump_thermals_to_cup_file(self.flight, tmp_cup_file)
+        self.assertFileNotEmpty(tmp_cup_file)
+
+    def testKmlDumpNotEmpty(self):
+        tmp_kml_file = os.path.join(self.tmp_output_dir, 'flight.kml')
+        dumpers.dump_flight_to_kml(self.flight, tmp_kml_file)
+        self.assertFileNotEmpty(tmp_kml_file)
+
+    def testCsvDumpsNotEmpty(self):
+        tmp_csv_track = os.path.join(self.tmp_output_dir, 'flight.csv')
+        tmp_csv_thermals = os.path.join(self.tmp_output_dir, 'thermals.csv')
+        dumpers.dump_flight_to_csv(
+            self.flight, tmp_csv_track, tmp_csv_thermals)
+        self.assertFileNotEmpty(tmp_csv_track)
+        self.assertFileNotEmpty(tmp_csv_thermals)

--- a/test_igc_lib.py
+++ b/test_igc_lib.py
@@ -1,11 +1,6 @@
-#!/usr/bin/env python
-import os
-import shutil
 import unittest
-import tempfile
 
 import igc_lib
-import dumpers
 
 
 class TestNapretTaskParsing(unittest.TestCase):
@@ -97,46 +92,3 @@ class TestNapretFlightParsing(unittest.TestCase):
     def testSomeFixesAreNotInCircling(self):
         self.assertTrue(
             any(map(lambda fix: not fix.circling, self.flight.fixes)))
-
-
-class TestDumpers(unittest.TestCase):
-
-    def setUp(self):
-        igc_file = 'testfiles/napret.igc'
-        self.flight = igc_lib.Flight.create_from_file(igc_file)
-        self.tmp_output_dir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        # Best-effort removal of temporary output files
-        shutil.rmtree(self.tmp_output_dir, ignore_errors=True)
-
-    def assertFileNotEmpty(self, filename):
-        self.assertTrue(os.path.isfile(filename))
-        self.assertGreater(os.path.getsize(filename), 0)
-
-    def testWptDumpNotEmpty(self):
-        tmp_wpt_file = os.path.join(self.tmp_output_dir, 'thermals.wpt')
-        dumpers.dump_thermals_to_wpt_file(self.flight, tmp_wpt_file)
-        self.assertFileNotEmpty(tmp_wpt_file)
-
-    def testCupDumpNotEmpty(self):
-        tmp_cup_file = os.path.join(self.tmp_output_dir, 'thermals.cup')
-        dumpers.dump_thermals_to_cup_file(self.flight, tmp_cup_file)
-        self.assertFileNotEmpty(tmp_cup_file)
-
-    def testKmlDumpNotEmpty(self):
-        tmp_kml_file = os.path.join(self.tmp_output_dir, 'flight.kml')
-        dumpers.dump_flight_to_kml(self.flight, tmp_kml_file)
-        self.assertFileNotEmpty(tmp_kml_file)
-
-    def testCsvDumpsNotEmpty(self):
-        tmp_csv_track = os.path.join(self.tmp_output_dir, 'flight.csv')
-        tmp_csv_thermals = os.path.join(self.tmp_output_dir, 'thermals.csv')
-        dumpers.dump_flight_to_csv(
-            self.flight, tmp_csv_track, tmp_csv_thermals)
-        self.assertFileNotEmpty(tmp_csv_track)
-        self.assertFileNotEmpty(tmp_csv_thermals)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Move dumper tests to a separate file. Test files are no longer executable, there's a starter to kick off all tests (run_tests.sh).
