### PR TITLE
Update igc_lib.py

### DIFF
--- a/igc_lib.py
+++ b/igc_lib.py
@@ -284,7 +284,7 @@ class GNSSFix:
             + '(\d\d)(\d\d)(\d\d\d)([NS])'
             + '(\d\d\d)(\d\d)(\d\d\d)([EW])'
             + '([AV])' + '([-\d]\d\d\d\d)' + '([-\d]\d\d\d\d)'
-            + '([0-9a-zA-Z]*).*$', B_record_line)
+            + '([0-9a-zA-Z\-]*).*$', B_record_line)
         if match is None:
             return None
         (hours, minutes, seconds,


### PR DESCRIPTION
Stating the IGC specification for the 'VAT':

Compensated variometer (total energy/NETTO) vertical speed in metres per second and tenths of metres per second with leading zero and no dot (".") separator between metres and tenths. Valid characters 0-9 and negative sign "-". Negative values to have negative sign instead of leading zero.

Proposed change in regular expression allows for negative sign in extras of B record.