### PR TITLE
Update igc_lib.py

### DIFF
--- a/igc_lib.py
+++ b/igc_lib.py
@@ -978,7 +978,7 @@ class Flight:
 
         # Step 2: apply _config.min_landing_time.
         ignore_next_downtime = False
-        apply_next_downtime = False
+        apply_next_downtime = True
         for i, (fix, output) in enumerate(zip(self.fixes, outputs)):
             if output == 1:
                 fix.flying = True


### PR DESCRIPTION
_compute_takeoff_landing failed on this flight: https://www.onlinecontest.org/olc-3.0/gliding/flightinfo.html?dsId=7571663
Takeoff is on roughly on the 13th fix. However, going through compute_flight, the first fix is automatically going to be set to fix.flying = True, even if output = 0 for the first Fix. This is due to ignore_next_downtime and apply_next_downtime both being set to False. 
I have done no thorough testing, but setting apply_next_downtime to False for the start finds the correct takeoff_fix.